### PR TITLE
testing retrieval of latest viable commit

### DIFF
--- a/.github/scripts/print_latest_commits.py
+++ b/.github/scripts/print_latest_commits.py
@@ -28,7 +28,7 @@ def get_latest_commits() -> List[str]:
             "-n",
             "1",
             "--pretty=format:%H",
-            "origin/viable/strict",
+            "upstream/viable/strict",
         ],
         encoding="ascii",
     )
@@ -37,7 +37,7 @@ def get_latest_commits() -> List[str]:
             "git",
             "rev-list",
             f"{latest_viable_commit}^..HEAD",
-            "--remotes=*origin/master",
+            "--remotes=*upstream/master",
         ],
         encoding="ascii",
     ).splitlines()

--- a/.github/workflows/update-viablestrict.yml
+++ b/.github/workflows/update-viablestrict.yml
@@ -1,0 +1,43 @@
+name: Update viable/strict
+
+on:
+  schedule:
+    - cron: */30 * * * *
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  do_update_viablestrict:
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+          architecture: x64
+          
+      - name: Checkout PyTorch
+        uses: pytorch/pytorch/.github/actions/checkout-pytorch@master
+
+      - name: Install Python Packages
+        run: |
+          pip3 install rockset==0.8.10
+
+      - name: Get latest viable commit
+        env:
+          ROCKSET_API_KEY: ${{ secrets.ROCKSET_API_KEY }}
+        run: |
+          output=$(python3 -m .github/scripts/print_latest_commits.py)
+          echo "::set-output name=latest_viable_sha::$output"
+        id: get-latest-commit
+
+      - name: Push SHA to viable/strict branch
+        run: |
+          git config --global user.email "pytorchmergebot@users.noreply.github.com"
+          git config --global user.name "PyTorch MergeBot"
+          echo "::debug::Set the latest sha variable to be ${{ steps.get-latest-commit.outputs.latest_viable_sha }}" 
+        # git push origin "${{ steps.get-latest-commit.outputs.latest_viable_sha }}":refs/remotes/origin/viable/strict 
+       
+      # is this origin? also is the remote branch name this or refs/heads/<remotebranchname> 


### PR DESCRIPTION
**Overview:** Testing if the get latest viable commit step is correct. It should print the correct SHA in the GHA while running. 

**Test Plan:** This first PR tests if we can retrieve the correct promote-able sha from the `print_latest_commits.py` script. Compare the result from GHA with HUD and local runs.